### PR TITLE
add support for multiple targets

### DIFF
--- a/bin/lerna-watch.js
+++ b/bin/lerna-watch.js
@@ -10,7 +10,7 @@ const { watch } = require('../lib')
 const pkg = require('../package.json')
 const man = require('../lib/man')
 
-const targetName = argv._[0]
+const targets = argv._
 
 if (argv.version) {
   console.log(`${pkg.version}`)
@@ -25,7 +25,7 @@ if (argv.help) {
 try {
   watch({
     cwd: process.cwd(),
-    target: targetName
+    targets: targets
   })
 } catch (err) {
   // suppress errors in cli mode

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ module.exports.watch = watch
 
 /**
  * @param args <object>
- * @param args.target <string> top-level application target
+ * @param args.targets <string[]> top-level application target
  * @param args.project <?@lerna/project> project object
  * @param args.cwd <?string> only necessary if not passing a project
  */
@@ -31,31 +31,49 @@ function watch (args) {
     throw new ProjectError(msg)
   }
 
-  if (!args.target) {
-    const msg = 'No target supplied'
+  if (args.target && !args.targets) {
+    args.targets = [args.target]
+  }
+
+  if (!args.targets) {
+    const msg = 'No target(s) supplied'
     log.error(msg)
     throw new TargetError(msg)
   }
 
   const packages = project.getPackagesSync()
   const graph = new PackageGraph(packages)
-  const target = graph.get(args.target)
 
-  if (!target) {
-    const msg = 'Can not find package target'
+  const targets = args.targets.reduce((targets, targetName) => {
+    const target = graph.get(targetName)
+    if (!target) {
+      log.error(`Can not find package ${targetName}, ignoring`)
+    } else {
+      targets = targets.concat(target)
+    }
+    return targets
+  }, [])
+
+  if (targets.length === 0) {
+    const msg = 'No valid packages found.'
     log.error(msg)
     throw new TargetError(msg)
   }
 
-  debug(`Evaluating dependencies of target ${target.name}`)
-  const deps = getTargetLocalDependencies(target, graph)
+  const deps = new Map()
+  for (const target of targets) {
+    debug(`Evaluating dependencies of target ${target.name}`)
+    const targetDeps = getTargetLocalDependencies(target, graph)
 
-  log.info('target', target.name)
-  logMapKeys(deps, 'local dependencies')
+    log.info('target', target.name)
+    logMapKeys(targetDeps, 'local dependencies')
+
+    targetDeps.forEach((dep) => deps.set(dep.name, dep))
+  }
 
   const commands = getConfigCommands(project)
 
   // Fire into target and dependency commands
-  runCommand([target], commands.target)
+  runCommand(targets, commands.target)
   runCommand(Array.from(deps.values()), commands.watch)
 }

--- a/lib/man.js
+++ b/lib/man.js
@@ -4,12 +4,12 @@ const pkg = require('../package.json')
 module.exports = `
 ${pkg.name} ${pkg.version}
 
-Usage: 
+Usage:
 
-  ${pkg.name} <target>
+  ${pkg.name} <targets>
 
-Target is a package within the lerna-powered monorepo. 
-The local dependency graph will be evaluated and scripts will begin to 
+Target is a package within the lerna-powered monorepo.
+The local dependency graph will be evaluated and scripts will begin to
 run in the target and its local dependencies. These scripts are defined
 within lerna.json.
 `


### PR DESCRIPTION
Cool project!

I wanted to run 2 node apps in parallel. So, I modified the code to allow for multiple targets.

```
lerna-watch target-1 target-2
```
or
```
watch({targets:["target-1", "target-2"]})
```

The API should be backwards compatible, at least as far as I can tell.

Thoughts?